### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A [Model Context Protocol](https://github.com/modelcontextprotocol) server for t
 
 This integration enables Large Language Models (LLMs) to interact directly with QA Sphere test cases, allowing you to discover, summarize, and chat about test cases. In AI-powered IDEs that support MCP, you can reference specific QA Sphere test cases within your development workflow.
 
+<a href="https://glama.ai/mcp/servers/@Hypersequent/qasphere-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Hypersequent/qasphere-mcp/badge" alt="qasphere-mcp MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js (recent LTS versions)


### PR DESCRIPTION
This PR adds a badge for the [qasphere-mcp](https://glama.ai/mcp/servers/@Hypersequent/qasphere-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Hypersequent/qasphere-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Hypersequent/qasphere-mcp/badge" alt="qasphere-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an HTML badge linking to the QA Sphere MCP server page near the top of the README.
  - Made a minor whitespace adjustment at the end of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->