### PR TITLE
add e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,140 @@
+name: E2E Tests with Claude
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test_scope:
+        description: 'Scope of tests to run'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - projects
+          - tcases
+          - folders
+          - tags
+          - requirements
+          - custom-fields
+          - shared-steps
+          - shared-preconditions
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    env:
+      TEST_SCOPE: ${{ github.event.inputs.test_scope || 'all' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build MCP server
+        run: npm run build
+
+      - name: Create MCP Config
+        env:
+          QASPHERE_TENANT_URL: ${{ secrets.QASPHERE_TENANT_URL }}
+          QASPHERE_API_KEY: ${{ secrets.QASPHERE_API_KEY }}
+        run: |
+          cat > /tmp/mcp-config.json << EOF
+          {
+            "mcpServers": {
+              "qasphere": {
+                "command": "node",
+                "args": ["${{ github.workspace }}/dist/index.js"],
+                "env": {
+                  "QASPHERE_TENANT_URL": "${QASPHERE_TENANT_URL}",
+                  "QASPHERE_API_KEY": "${QASPHERE_API_KEY}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Run Claude E2E Tests
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --mcp-config /tmp/mcp-config.json
+          prompt: |
+            # QA Sphere MCP E2E Test Run
+
+            You are running E2E tests for the QA Sphere MCP server. The MCP server is already built and configured.
+            You have access to the `qasphere` MCP server with tools like `mcp__qasphere__list_projects`, `mcp__qasphere__get_project`, etc.
+
+            ## Test Scope: ${{ env.TEST_SCOPE }}
+
+            ## Instructions
+
+            1. Use the QA Sphere MCP tools to verify they work correctly
+            2. For each tool, make a real API call and verify the response
+            3. Report results in a structured format
+
+            ## Test Cases to Execute
+
+            ### Projects Tests
+            - [ ] `list_projects` - List all projects and verify response structure
+            - [ ] `get_project` - Get a specific project (use project code from list)
+
+            ### Test Cases Tests (if scope includes tcases or all)
+            - [ ] `list_test_cases` - List test cases from a project
+            - [ ] `get_test_case` - Get a specific test case by marker
+            - [ ] `create_test_case` - Create a new test case (use E2E folder)
+            - [ ] `update_test_case` - Update the created test case
+
+            ### Folders Tests (if scope includes folders or all)
+            - [ ] `list_folders` - List folders in a project
+            - [ ] `upsert_folders` - Create/update a test folder named "MCP-E2E-Tests"
+
+            ### Tags Tests (if scope includes tags or all)
+            - [ ] `list_test_cases_tags` - List all tags in a project
+
+            ### Requirements Tests (if scope includes requirements or all)
+            - [ ] `list_requirements` - List requirements in a project
+
+            ### Custom Fields Tests (if scope includes custom-fields or all)
+            - [ ] `list_custom_fields` - List custom fields in a project
+
+            ### Shared Steps Tests (if scope includes shared-steps or all)
+            - [ ] `list_shared_steps` - List shared steps in a project
+
+            ### Shared Preconditions Tests (if scope includes shared-preconditions or all)
+            - [ ] `list_shared_preconditions` - List shared preconditions in a project
+
+            ## Expected Output Format
+
+            For each test, report:
+            ```
+            PASS: tool_name - Brief description of what was verified
+            FAIL: tool_name - Error message or unexpected behavior
+            SKIP: tool_name - Reason for skipping
+            ```
+
+            ## Important Notes
+            - First call list_projects to discover available projects
+            - Use the first available project for testing
+            - Create test artifacts in a folder named "MCP-E2E-Tests"
+            - Clean up any test cases you create (but keep the folder for future runs)
+            - If a test fails, continue with remaining tests
+            - Provide a final summary with pass/fail counts
+
+            Please execute the tests now and provide a summary report.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       test_scope:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "qasphere": {
+      "command": "node",
+      "args": ["dist/index.js"],
+      "env": {
+        "QASPHERE_TENANT_URL": "${QASPHERE_TENANT_URL}",
+        "QASPHERE_API_KEY": "${QASPHERE_API_KEY}"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# QA Sphere MCP Server - Development Guide
+
+## Project Overview
+
+MCP (Model Context Protocol) server enabling LLMs to interact with QA Sphere test management system. Built with TypeScript, uses stdio transport.
+
+## Architecture
+
+```
+src/
+├── index.ts              # Entry point - creates MCP server
+├── config.ts             # Environment config (QASPHERE_TENANT_URL, QASPHERE_API_KEY)
+├── types.ts              # TypeScript interfaces for API responses
+├── schemas.ts            # Zod schemas for input validation
+├── utils.ts              # JSON utilities
+├── LoggingTransport.ts   # Debug logging (MCP_LOG_TO_FILE)
+└── tools/                # MCP tool handlers (one file per domain)
+    ├── index.ts          # Registers all tools
+    ├── projects.ts       # list_projects, get_project
+    ├── tcases.ts         # list_test_cases, get_test_case, create_test_case, update_test_case
+    ├── folders.ts        # list_folders, upsert_folders
+    ├── tags.ts           # list_test_cases_tags
+    ├── requirements.ts   # list_requirements
+    ├── customFields.ts   # list_custom_fields
+    ├── shared-steps.ts   # list_shared_steps
+    └── shared-preconditions.ts  # list_shared_preconditions
+```
+
+## Commands
+
+```bash
+npm run dev              # Run with tsx (development)
+npm run build            # Compile TypeScript
+npm run typecheck        # Type check without emit
+npm run lint             # Biome lint (auto-fix)
+npm run format           # Biome format
+npm run inspector        # MCP Inspector for debugging
+npm test                 # Unit tests
+npm run test:integration # Integration tests (requires env vars)
+```
+
+## Adding a New Tool
+
+1. Create `src/tools/{domain}.ts`:
+```typescript
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
+import axios from 'axios'
+import { QASPHERE_API_KEY, QASPHERE_TENANT_URL } from '../config.js'
+import { projectCodeSchema } from '../schemas.js'
+
+export const registerTools = (server: McpServer) => {
+  server.tool(
+    'tool_name',                    // Tool identifier
+    'Description for the LLM',      // Description
+    { projectCode: projectCodeSchema },  // Input schema (Zod)
+    async ({ projectCode }) => {
+      const response = await axios.get(
+        `${QASPHERE_TENANT_URL}/api/public/v0/...`,
+        { headers: { Authorization: `ApiKey ${QASPHERE_API_KEY}` } }
+      )
+      return { content: [{ type: 'text', text: JSON.stringify(response.data) }] }
+    }
+  )
+}
+```
+
+2. Register in `src/tools/index.ts`:
+```typescript
+import { registerTools as registerNewTools } from './new-domain.js'
+// Add to registerTools function
+registerNewTools(server)
+```
+
+3. Add types to `src/types.ts`, schemas to `src/schemas.ts`
+
+4. Create tests in `src/tests/unit/tools/{domain}.test.ts`
+
+## Testing
+
+### Unit Tests
+- Mock axios, test tool registration and handlers
+- Location: `src/tests/unit/`
+- Fixtures: `src/tests/fixtures/`
+
+### Integration Tests
+- Real API calls against test tenant
+- Requires `.env` with `QASPHERE_TENANT_URL`, `QASPHERE_API_KEY`, `QASPHERE_AUTH_EMAIL`, `QASPHERE_AUTH_PASSWORD`
+- Location: `src/tests/integration/`
+- Uses shared session token, rate limit handling
+
+### E2E Tests
+- GitHub Action triggers Claude to exercise all MCP tools
+- Runs on PRs and main merges
+- Manual trigger via Actions tab
+
+## Code Style
+
+- Biome for linting/formatting (pre-commit hook)
+- ES modules (`.js` extension in imports)
+- Explicit error handling for axios errors
+- Return MCP content format: `{ content: [{ type: 'text', text: string }] }`
+
+## API Authentication
+
+All QA Sphere API calls use:
+```
+Authorization: ApiKey {QASPHERE_API_KEY}
+Content-Type: application/json
+```
+
+Base URL pattern: `{QASPHERE_TENANT_URL}/api/public/v0/...`
+
+## Debugging
+
+Enable MCP message logging:
+```bash
+MCP_LOG_TO_FILE=/tmp/mcp.log npm run dev
+```
+
+Use MCP Inspector:
+```bash
+npm run inspector
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This integration enables Large Language Models (LLMs) to interact directly with 
 
 - Node.js (recent LTS versions)
 - QA Sphere account with API access
-- API key from QA Sphere (Settings ⚙️ → API Keys → Add API Key)
+- API key from QA Sphere (Settings → API Keys → Add API Key)
 - Your company's QA Sphere URL (e.g., `example.eu2.qasphere.com`)
 
 ## Setup Instructions
@@ -62,6 +62,222 @@ For any MCP client, use the following configuration format:
 ```
 
 Replace the placeholder values with your actual QA Sphere URL and API key.
+
+## Available Tools
+
+This MCP server provides 16 tools organized by domain:
+
+### Projects
+
+#### `list_projects`
+Get a list of all projects from the current QA Sphere account.
+
+**Parameters:** None
+
+---
+
+#### `get_project`
+Get project information using a project code.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier (2-5 uppercase alphanumeric characters, e.g., `BDI`) |
+
+---
+
+### Test Cases
+
+#### `list_test_cases`
+List test cases from a project with pagination, filtering, and sorting options.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier (e.g., `BDI`) |
+| `page` | number | No | Page number for pagination |
+| `limit` | number | No | Number of items per page (default: 20) |
+| `sortField` | enum | No | Sort by: `id`, `seq`, `folder_id`, `author_id`, `pos`, `title`, `priority`, `created_at`, `updated_at`, `legacy_id` |
+| `sortOrder` | enum | No | Sort direction: `asc` or `desc` |
+| `search` | string | No | Search term to filter test cases |
+| `include` | array | No | Related data to include: `steps`, `tags`, `project`, `folder`, `path`, `requirements` |
+| `folders` | array | No | Filter by folder IDs |
+| `tags` | array | No | Filter by tag IDs |
+| `priorities` | array | No | Filter by priority: `high`, `medium`, `low` |
+| `draft` | boolean | No | Filter draft vs published test cases |
+| `requirementIds` | array | No | Filter by requirement IDs (OR logic) |
+
+---
+
+#### `get_test_case`
+Get a single test case using its marker.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `marker` | string | Yes | Test case marker in format `PROJECT_CODE-SEQUENCE` (e.g., `BDI-123`) |
+
+---
+
+#### `create_test_case`
+Create a new test case. Supports standalone and template test cases.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectId` | string | Yes | Project code identifier |
+| `title` | string | Yes | Test case title (1-511 characters) |
+| `type` | enum | Yes | Type: `standalone` or `template` |
+| `folderId` | number | Yes | ID of the folder for the test case |
+| `priority` | enum | Yes | Priority: `high`, `medium`, or `low` |
+| `pos` | number | No | Position within folder (0-based index) |
+| `precondition` | object | No | Either `{ sharedPreconditionId: number }` or `{ text: string }` (HTML format) |
+| `steps` | array | No | Array of step objects with `description`, `expected` (HTML), or `sharedStepId` |
+| `tags` | array | No | Array of tag titles (strings) |
+| `requirements` | array | No | Array of `{ text: string, url: string }` objects |
+| `links` | array | No | Array of `{ text: string, url: string }` objects |
+| `customFields` | object | No | Custom field values keyed by `systemName` |
+| `parameterValues` | array | No | Values for template parameters |
+| `filledTCaseTitleSuffixParams` | array | No | Parameters to append to filled test case titles |
+| `isDraft` | boolean | No | Create as draft (default: false) |
+
+---
+
+#### `update_test_case`
+Update an existing test case. Only specified fields are updated.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectId` | string | Yes | Project code identifier |
+| `tcaseOrLegacyId` | string | Yes | Test case UUID, sequence number, or legacy ID |
+| `title` | string | No | Test case title (1-511 characters) |
+| `priority` | enum | No | Priority: `high`, `medium`, or `low` |
+| `precondition` | object | No | Either `{ sharedPreconditionId: number }` or `{ text: string }` |
+| `isDraft` | boolean | No | Publish a draft (cannot convert published to draft) |
+| `steps` | array | No | Array of step objects |
+| `tags` | array | No | Array of tag titles |
+| `requirements` | array | No | Array of requirement objects |
+| `links` | array | No | Array of link objects |
+| `customFields` | object | No | Custom field values |
+| `parameterValues` | array | No | Values for template parameters (include `tcaseId` to update existing) |
+
+---
+
+### Folders
+
+#### `list_folders`
+List folders for test cases within a project.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `page` | number | No | Page number for pagination |
+| `limit` | number | No | Number of items per page (default: 100) |
+| `sortField` | enum | No | Sort by: `id`, `project_id`, `title`, `pos`, `parent_id`, `created_at`, `updated_at` |
+| `sortOrder` | enum | No | Sort direction: `asc` or `desc` |
+
+---
+
+#### `upsert_folders`
+Create or update multiple folders using path hierarchies. Automatically creates nested structures.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `folders` | array | Yes | Array of folder objects with `path` (array of folder names) and optional `comment` (HTML) |
+
+**Example:**
+```json
+{
+  "projectCode": "BDI",
+  "folders": [
+    { "path": ["Login", "Authentication", "OAuth"], "comment": "<p>OAuth test cases</p>" },
+    { "path": ["Login", "Authentication", "SAML"] }
+  ]
+}
+```
+
+---
+
+### Tags
+
+#### `list_test_cases_tags`
+List all tags defined within a project.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+
+---
+
+### Requirements
+
+#### `list_requirements`
+List requirements linked to test cases. Useful for filtering test cases by requirement.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `sortField` | enum | No | Sort by: `created_at` or `text` |
+| `sortOrder` | enum | No | Sort direction: `asc` or `desc` (requires `sortField`) |
+| `include` | enum | No | Include `tcaseCount` for linked test case counts |
+
+---
+
+### Custom Fields
+
+#### `list_custom_fields`
+List all custom fields available for a project. Use when creating/updating test cases with custom field values.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+
+---
+
+### Shared Steps
+
+#### `list_shared_steps`
+List reusable shared steps for a project.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `sortField` | enum | No | Sort by: `created_at` or `title` |
+| `sortOrder` | enum | No | Sort direction: `asc` or `desc` (requires `sortField`) |
+| `include` | enum | No | Include `tcaseCount` for usage counts |
+
+---
+
+#### `get_shared_step`
+Get details for a single shared step.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `sharedStepId` | number | Yes | Shared step ID (positive integer) |
+
+---
+
+### Shared Preconditions
+
+#### `list_shared_preconditions`
+List reusable shared preconditions for a project.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `sortField` | enum | No | Sort by: `created_at` or `title` |
+| `sortOrder` | enum | No | Sort direction: `asc` or `desc` (requires `sortField`) |
+| `include` | enum | No | Include `tcaseCount` for usage counts |
+
+---
+
+#### `get_shared_precondition`
+Get details for a single shared precondition.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectCode` | string | Yes | Project code identifier |
+| `sharedPreconditionId` | number | Yes | Shared precondition ID (positive integer) |
+
+---
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,39 @@ For any MCP client, use the following configuration format:
 
 Replace the placeholder values with your actual QA Sphere URL and API key.
 
+## Development
+
+### Running Tests
+
+```bash
+# Unit tests
+npm test
+
+# Integration tests (requires environment variables)
+npm run test:integration
+```
+
+### E2E Testing with Claude
+
+The project includes an E2E testing workflow that uses Claude Code to exercise all MCP tools against a real QA Sphere instance.
+
+#### Required GitHub Secrets
+
+To run E2E tests, configure these secrets in your repository:
+
+| Secret | Description |
+|--------|-------------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for Claude Code Action |
+| `QASPHERE_TENANT_URL` | Your QA Sphere tenant URL (e.g., `https://example.eu1.qasphere.com`) |
+| `QASPHERE_API_KEY` | API key with access to test projects |
+
+#### Running E2E Tests
+
+1. Go to **Actions** → **E2E Tests with Claude**
+2. Click **Run workflow**
+3. Select test scope (`all`, `projects`, `tcases`, etc.)
+4. Review Claude's test report in the workflow output
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- Add GitHub Actions E2E test workflow using Claude Code Action
- Run automated tests against all QA Sphere MCP tools with real API calls
- Trigger on pushes to main, PRs to all branches, and manual dispatch

## Test Coverage
- Projects: `list_projects`, `get_project`
- Test Cases: `list_test_cases`, `get_test_case`, `create_test_case`, `update_test_case`
- Folders: `list_folders`, `upsert_folders`
- Tags: `list_test_cases_tags`
- Requirements: `list_requirements`
- Custom Fields: `list_custom_fields`
- Shared Steps: `list_shared_steps`
- Shared Preconditions: `list_shared_preconditions`

## Configuration
- Supports scoped test runs via `workflow_dispatch` input
- Uses `QASPHERE_TENANT_URL`, `QASPHERE_API_KEY`, and `CLAUDE_CODE_OAUTH_TOKEN` secrets