### PR TITLE
Add npm publish workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically publish to npm when a release is created
- Uses OIDC trusted publishing (no stored tokens needed)
- Includes provenance attestation for supply chain security

## Setup Required
After merging, configure npm to trust this repo:
1. Go to https://www.npmjs.com/package/qasphere-mcp → Settings
2. Under "Publishing access", click "Add GitHub Workflow"
3. Set repository to `Hypersequent/qasphere-mcp` and workflow to `publish.yml`

## Test plan
- [ ] Merge PR
- [ ] Configure npm trusted publishing
- [ ] Create a GitHub release
- [ ] Verify package is published to npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)