### PR TITLE
Fix publish workflow: skip missing test script and bump to Node 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: npm test --if-present
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Use `npm test --if-present` so the publish job doesn't fail when no `test` script exists, while keeping the step as a placeholder for when tests are added
- Bump the workflow's Node to 22 to match `engines.node` in package.json (raised in #21)

## Context
The v0.4.0 release fired the publish workflow but failed at the test step because there's no `test` script in package.json. With `--if-present`, npm exits 0 instead of 1.

## Test plan
- [ ] Merge, then re-trigger publish by recreating the v0.4.0 release/tag
- [ ] Confirm workflow run succeeds and the package lands on npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)