### PR TITLE
Bump publish workflow to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Bump the publish workflow's Node version from 22 to 24

## Why
Node 24 ships with npm >= 11, which is required for npm trusted publishing via OIDC. Node 22's bundled npm (10.x) lacks support and was causing v0.4.0 publishes to fail with `E404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)