### PR TITLE
Fix MCP stdio breakage: silence dotenv banner (v0.4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qasphere-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qasphere-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qasphere-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for QA Sphere integration",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 
-dotenv.config()
+dotenv.config({ quiet: true })
 
 // Validate required environment variables
 const requiredEnvVars = ['QASPHERE_TENANT_URL', 'QASPHERE_API_KEY']


### PR DESCRIPTION
## Problem

MCP clients (e.g. Claude Desktop) fail to start the server with:

> Unexpected token '◇', "◇ injected"... is not valid JSON

## Cause

`dotenv@17` prints a promotional banner to **stdout** on `config()`:

```
◇ injected env (0) from .env // tip: ◈ encrypted .env [www.dotenvx.com]
```

MCP communicates over **stdio** using JSON-RPC, so that banner becomes the first bytes the client reads → JSON parse error. (This is `dotenv` itself, not dotenvx.)

## Fix

Pass `quiet: true` to `dotenv.config()` — the option dotenv v17 added specifically to suppress the banner.

```diff
-dotenv.config()
+dotenv.config({ quiet: true })
```

## Verification

Ran the built server with required env vars and `stdin` closed:

- **stdout**: empty ✅ (was the banner)
- **stderr**: `QA Sphere MCP server started` ✅ (stderr is fine for MCP)

Bumps version to **0.4.1** so a release can publish the fix to npm (clients run `npx qasphere-mcp`, which pulls the published version).