### PR TITLE
Use new bearer auth scheme and offset+limit pagination (v0.5.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qasphere-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "MCP server for QA Sphere integration",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,7 @@ export async function apiQuery<T extends z.ZodTypeAny>(
   const url = `${QASPHERE_TENANT_URL}${path}${buildQueryString(opts.query)}`
   const method = opts.method ?? 'GET'
   const headers: Record<string, string> = {
-    Authorization: `ApiKey ${QASPHERE_API_KEY}`,
+    Authorization: `Bearer ${QASPHERE_API_KEY}`,
   }
   if (opts.body !== undefined) {
     headers['Content-Type'] = 'application/json'

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -349,10 +349,10 @@ export const listTestCasesInputSchema = z.object({
     .number()
     .int()
     .min(0)
-    .max(1000)
+    .max(5000)
     .default(20)
     .describe(
-      'Maximum number of test cases to return (0-1000, defaults to 20). Use 0 to fetch only the total count'
+      'Maximum number of test cases to return (0-5000, defaults to 20). Use 0 to fetch only the total count'
     ),
   sortField: z
     .enum([
@@ -616,10 +616,10 @@ export const listFoldersInputSchema = z.object({
     .number()
     .int()
     .min(0)
-    .max(1000)
+    .max(5000)
     .default(20)
     .describe(
-      'Maximum number of folders to return (0-1000, defaults to 20). Use 0 to fetch only the total count'
+      'Maximum number of folders to return (0-5000, defaults to 20). Use 0 to fetch only the total count'
     ),
   sortField: z
     .enum(['id', 'project_id', 'title', 'pos', 'parent_id', 'created_at', 'updated_at'])

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -339,8 +339,21 @@ export type GetTestCaseOutput = z.infer<typeof getTestCaseOutputSchema>
 
 export const listTestCasesInputSchema = z.object({
   projectCode: projectCodeSchema,
-  page: z.number().optional().describe('Page number for pagination'),
-  limit: z.number().optional().default(20).describe('Number of items per page'),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Number of test cases to skip before returning results (defaults to 0)'),
+  limit: z
+    .number()
+    .int()
+    .min(0)
+    .max(1000)
+    .default(20)
+    .describe(
+      'Maximum number of test cases to return (0-1000, defaults to 20). Use 0 to fetch only the total count'
+    ),
   sortField: z
     .enum([
       'id',
@@ -404,8 +417,8 @@ export type ListTestCasesInput = z.infer<typeof listTestCasesInputSchema>
 
 export const listTestCasesOutputSchema = z.object({
   total: z.number().describe('Total number of filtered test cases'),
-  page: z.number().describe('Current page number'),
-  limit: z.number().describe('Number of test cases per page'),
+  offset: z.number().describe('Offset applied to the query'),
+  limit: z.number().describe('Limit applied to the query'),
   data: z
     .array(
       getTestCaseOutputSchema.extend({
@@ -593,8 +606,21 @@ export type UpdateTestCaseOutput = z.infer<typeof updateTestCaseOutputSchema>
 
 export const listFoldersInputSchema = z.object({
   projectCode: projectCodeSchema,
-  page: z.number().optional().describe('Page number for pagination'),
-  limit: z.number().optional().default(100).describe('Number of items per page'),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Number of folders to skip before returning results (defaults to 0)'),
+  limit: z
+    .number()
+    .int()
+    .min(0)
+    .max(1000)
+    .default(20)
+    .describe(
+      'Maximum number of folders to return (0-1000, defaults to 20). Use 0 to fetch only the total count'
+    ),
   sortField: z
     .enum(['id', 'project_id', 'title', 'pos', 'parent_id', 'created_at', 'updated_at'])
     .optional()
@@ -608,8 +634,8 @@ export type ListFoldersInput = z.infer<typeof listFoldersInputSchema>
 
 export const listFoldersOutputSchema = z.object({
   total: z.number().describe('Total number of items available'),
-  page: z.number().describe('Current page number'),
-  limit: z.number().describe('Number of items per page'),
+  offset: z.number().describe('Offset applied to the query'),
+  limit: z.number().describe('Limit applied to the query'),
   data: z.array(testFolderSchema).nullable().describe('List of folders'),
 })
 export type ListFoldersOutput = z.infer<typeof listFoldersOutputSchema>

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -18,11 +18,11 @@ export const registerTools = (server: McpServer) => {
       inputSchema: listFoldersInputSchema.shape,
       outputSchema: listFoldersOutputSchema.shape,
     },
-    async ({ projectCode, page, limit, sortField, sortOrder }) => {
+    async ({ projectCode, offset, limit, sortField, sortOrder }) => {
       try {
         const result = await apiQuery(`/api/public/v0/project/${projectCode}/tcase/folders`, {
           schema: listFoldersOutputSchema,
-          query: { page, limit, sortField, sortOrder },
+          query: { offset, limit, sortField, sortOrder },
         })
         return {
           content: [{ type: 'text', text: JSON.stringify(result) }],

--- a/src/tools/tcases.ts
+++ b/src/tools/tcases.ts
@@ -59,7 +59,7 @@ export const registerTools = (server: McpServer) => {
     },
     async ({
       projectCode,
-      page,
+      offset,
       limit,
       sortField,
       sortOrder,
@@ -76,7 +76,7 @@ export const registerTools = (server: McpServer) => {
     }) => {
       try {
         const query: Record<string, string | number | boolean | string[] | number[] | undefined> = {
-          page,
+          offset,
           limit,
           sortField,
           sortOrder,

--- a/tests/e2e/folders.test.ts
+++ b/tests/e2e/folders.test.ts
@@ -104,7 +104,7 @@ describe('folders', () => {
 
     beforeAll(async () => {
       // Seed enough folders so pagination assertions don't degenerate on a
-      // near-empty project. Five lets us check limit=2, limit=3, and page=2.
+      // near-empty project. Five lets us check limit=2, limit=3, and offset=2.
       await callTool<UpsertFoldersOutput>(client, 'upsert_folders', {
         projectCode,
         folders: ['a', 'b', 'c', 'd', 'e'].map((suffix) => ({
@@ -124,6 +124,16 @@ describe('folders', () => {
       expect(result.data?.some((f) => f.title === `${folderName}-a`)).toBe(true)
     })
 
+    it('returns a paginated list with metadata', async () => {
+      const result = await callTool<ListFoldersOutput>(client, 'list_folders', {
+        projectCode,
+      })
+      expect(typeof result.total).toBe('number')
+      // The input defaults (offset 0, limit 20) are applied and echoed back.
+      expect(result.offset).toBe(0)
+      expect(result.limit).toBe(20)
+    })
+
     it('respects limit=2 and limit=3 (backend honors pagination)', async () => {
       const r2 = await callTool<ListFoldersOutput>(client, 'list_folders', {
         projectCode,
@@ -141,28 +151,41 @@ describe('folders', () => {
       expect(r3.data?.length).toBe(3)
     })
 
-    it('returns non-overlapping items on page 2', async () => {
-      const page1 = await callTool<ListFoldersOutput>(client, 'list_folders', {
+    it('returns non-overlapping items with offset pagination', async () => {
+      const first = await callTool<ListFoldersOutput>(client, 'list_folders', {
         projectCode,
         limit: 2,
-        page: 1,
+        offset: 0,
         sortField: 'id',
         sortOrder: 'asc',
       })
-      const page2 = await callTool<ListFoldersOutput>(client, 'list_folders', {
+      const second = await callTool<ListFoldersOutput>(client, 'list_folders', {
         projectCode,
         limit: 2,
-        page: 2,
+        offset: 2,
         sortField: 'id',
         sortOrder: 'asc',
       })
-      expect(page1.data?.length).toBe(2)
-      expect(page2.data?.length).toBeGreaterThan(0)
-      expect(page2.page).toBe(2)
-      const page1Ids = new Set(page1.data?.map((f) => f.id))
-      for (const f of page2.data ?? []) {
-        expect(page1Ids.has(f.id)).toBe(false)
+      expect(first.data?.length).toBe(2)
+      expect(first.offset).toBe(0)
+      expect(first.limit).toBe(2)
+      expect(second.data?.length).toBeGreaterThan(0)
+      expect(second.offset).toBe(2)
+      expect(second.limit).toBe(2)
+      const firstIds = new Set(first.data?.map((f) => f.id))
+      for (const f of second.data ?? []) {
+        expect(firstIds.has(f.id)).toBe(false)
       }
+    })
+
+    it('returns only the total when limit=0', async () => {
+      const result = await callTool<ListFoldersOutput>(client, 'list_folders', {
+        projectCode,
+        limit: 0,
+      })
+      expect(result.limit).toBe(0)
+      expect(result.total).toBeGreaterThan(0)
+      expect(result.data ?? []).toHaveLength(0)
     })
 
     it('honors sortOrder asc vs desc on id', async () => {

--- a/tests/e2e/tcases.test.ts
+++ b/tests/e2e/tcases.test.ts
@@ -260,8 +260,9 @@ describe('test cases', () => {
         projectCode,
       })
       expect(typeof result.total).toBe('number')
-      expect(typeof result.page).toBe('number')
-      expect(typeof result.limit).toBe('number')
+      // The input defaults (offset 0, limit 20) are applied and echoed back.
+      expect(result.offset).toBe(0)
+      expect(result.limit).toBe(20)
     })
 
     it('respects limit=2 and limit=3 (backend honors pagination)', async () => {
@@ -283,30 +284,44 @@ describe('test cases', () => {
       expect(r3.data?.length).toBe(3)
     })
 
-    it('returns non-overlapping items on page 2', async () => {
-      const page1 = await callTool<ListTestCasesOutput>(client, 'list_test_cases', {
+    it('returns non-overlapping items with offset pagination', async () => {
+      const first = await callTool<ListTestCasesOutput>(client, 'list_test_cases', {
         projectCode,
         folders: [folderId],
         limit: 2,
-        page: 1,
+        offset: 0,
         sortField: 'seq',
         sortOrder: 'asc',
       })
-      const page2 = await callTool<ListTestCasesOutput>(client, 'list_test_cases', {
+      const second = await callTool<ListTestCasesOutput>(client, 'list_test_cases', {
         projectCode,
         folders: [folderId],
         limit: 2,
-        page: 2,
+        offset: 2,
         sortField: 'seq',
         sortOrder: 'asc',
       })
-      expect(page1.data?.length).toBe(2)
-      expect(page2.data?.length).toBeGreaterThan(0)
-      expect(page2.page).toBe(2)
-      const page1Ids = new Set(page1.data?.map((tc) => tc.id))
-      for (const tc of page2.data ?? []) {
-        expect(page1Ids.has(tc.id)).toBe(false)
+      expect(first.data?.length).toBe(2)
+      expect(first.offset).toBe(0)
+      expect(first.limit).toBe(2)
+      expect(second.data?.length).toBeGreaterThan(0)
+      expect(second.offset).toBe(2)
+      expect(second.limit).toBe(2)
+      const firstIds = new Set(first.data?.map((tc) => tc.id))
+      for (const tc of second.data ?? []) {
+        expect(firstIds.has(tc.id)).toBe(false)
       }
+    })
+
+    it('returns only the total when limit=0', async () => {
+      const result = await callTool<ListTestCasesOutput>(client, 'list_test_cases', {
+        projectCode,
+        folders: [folderId],
+        limit: 0,
+      })
+      expect(result.limit).toBe(0)
+      expect(result.total).toBeGreaterThanOrEqual(5)
+      expect(result.data ?? []).toHaveLength(0)
     })
 
     it('honors sortOrder asc vs desc on seq', async () => {


### PR DESCRIPTION
Reopens #25 against `main`. The original PR was stacked on `dev/himanshu/add-e2e-tests`, which GitHub auto-closed when that branch was deleted on merge of #24. Commits are cherry-picked unchanged from @hi-rai's branch (only the `package.json` version conflict was resolved, keeping 0.5.0).

## Why this is a fix, not just a refactor

The QA Sphere API no longer returns `page` in list responses unless `page` is explicitly passed, so `main`'s output schemas — which require `page` — fail response validation on `list_test_cases` and `list_folders`. Verified against a live tenant:

```
GET /api/public/v0/project/CIT/tcase?offset=2&limit=2  ->  {total: 24, offset: 2, limit: 2}
GET /api/public/v0/project/CIT/tcase?page=1&limit=2    ->  {total: 24, page: 1, offset: 0, limit: 2}
```

## Changes

- `Authorization: ApiKey` -> `Authorization: Bearer`. Verified non-breaking: the API accepts both schemes today (both return 200).
- `page` -> `offset` for `list_test_cases` and `list_folders`, with `limit` bounded to 0-5000.
- e2e tests updated for offset pagination.

## Verification

- `npm run build` and `npm run check` pass.
- Full e2e suite run against a live tenant: **53 passed, 2 skipped**.