### PR TITLE
Point users at the hosted QA Sphere MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,8 @@
 > installed locally.
 >
 > **Recommended setup:** in QA Sphere go to **Settings ⚙️ → MCP Server**, pick your
-> assistant and access level, paste or create an API key, and copy the generated
-> command. For Claude Code it looks like this:
->
-> ```sh
-> claude mcp add --transport http qasphere https://your-company.region.qasphere.com/api/mcp \
->   --header "Authorization: Bearer YOUR_API_KEY"
-> ```
+> assistant and access level, add an API key, and follow the setup instructions shown
+> there. See the [QA Sphere documentation](https://qasphere.com/docs) for details.
 >
 > The instructions below are kept for reference only. While running the standalone
 > server, it points this out once per session; set

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 >   --header "Authorization: Bearer YOUR_API_KEY"
 > ```
 >
-> The instructions below are kept for reference only.
+> The instructions below are kept for reference only. While running the standalone
+> server, it points this out once per session; set
+> `QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1` to silence that.
 
 A [Model Context Protocol](https://github.com/modelcontextprotocol) server for the [QA Sphere](https://qasphere.com/) test management system.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { LoggingTransport } from './LoggingTransport.js'
-import { SERVER_INSTRUCTIONS, startupBanner } from './migration-notice.js'
+import { buildServerInstructions, startupBanner } from './migration-notice.js'
 import { registerTools } from './tools/index.js'
 
 // Create MCP server
@@ -14,7 +14,7 @@ const server = new McpServer(
     version: process.env.npm_package_version || '0.0.0',
     description: 'QA Sphere MCP server for fetching test cases and projects.',
   },
-  { instructions: SERVER_INSTRUCTIONS }
+  { instructions: buildServerInstructions() }
 )
 
 registerTools(server)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,18 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { LoggingTransport } from './LoggingTransport.js'
+import { SERVER_INSTRUCTIONS, startupBanner } from './migration-notice.js'
 import { registerTools } from './tools/index.js'
 
 // Create MCP server
-const server = new McpServer({
-  name: 'qasphere-mcp',
-  version: process.env.npm_package_version || '0.0.0',
-  description: 'QA Sphere MCP server for fetching test cases and projects.',
-})
+const server = new McpServer(
+  {
+    name: 'qasphere-mcp',
+    version: process.env.npm_package_version || '0.0.0',
+    description: 'QA Sphere MCP server for fetching test cases and projects.',
+  },
+  { instructions: SERVER_INSTRUCTIONS }
+)
 
 registerTools(server)
 
@@ -31,6 +35,9 @@ async function startServer() {
 
   await server.connect(transport)
   console.error('QA Sphere MCP server started')
+
+  const banner = startupBanner()
+  if (banner) console.error(banner)
 }
 
 startServer().catch(console.error)

--- a/src/migration-notice.ts
+++ b/src/migration-notice.ts
@@ -29,7 +29,14 @@ export const MIGRATION_NOTICE = [
   'Set QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1 to silence this notice.',
 ].join('\n')
 
-/** Built per server construction so the opt-out reaches this surface too. */
+/**
+ * Built per server construction so the opt-out reaches this surface too.
+ *
+ * This carries the full notice even though the first tool result does as well.
+ * That redundancy is deliberate: instructions are the only surface a session
+ * that never calls a tool will see, and tool output is the only one some clients
+ * surface to the user. The relay directive keeps the model from saying it twice.
+ */
 export const buildServerInstructions = (): string =>
   isSuppressed()
     ? SERVER_SUMMARY

--- a/src/migration-notice.ts
+++ b/src/migration-notice.ts
@@ -1,15 +1,10 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { QASPHERE_TENANT_URL } from './config.js'
 
 /**
  * This package is archival: QA Sphere now serves MCP itself, so the standalone
  * server exists only for setups that have not migrated yet. Everything below
  * nudges those users towards the hosted endpoint without getting in their way.
  */
-export const HOSTED_MCP_URL = `${QASPHERE_TENANT_URL}/api/mcp`
-
-const HOSTED_MCP_COMMAND = `claude mcp add --transport http qasphere ${HOSTED_MCP_URL} --header "Authorization: Bearer YOUR_API_KEY"`
-
 const isSuppressed = (): boolean => {
   const value = process.env.QASPHERE_MCP_HIDE_MIGRATION_NOTICE
   return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false'
@@ -17,12 +12,11 @@ const isSuppressed = (): boolean => {
 
 export const MIGRATION_NOTICE = [
   'Tip: this standalone qasphere-mcp package is no longer maintained.',
-  `QA Sphere now serves MCP directly at ${HOSTED_MCP_URL}. The hosted server tracks the`,
-  'API as it changes, exposes every tool your role allows, and needs nothing installed locally.',
+  'QA Sphere now serves MCP directly. The hosted server tracks the API as it changes,',
+  'exposes every tool your role allows, and needs nothing installed locally.',
   '',
-  'Set it up in QA Sphere under Settings -> MCP Server, or for Claude Code run:',
-  '',
-  `  ${HOSTED_MCP_COMMAND}`,
+  'To switch, see Settings -> MCP Server in QA Sphere, or the QA Sphere documentation',
+  'at https://qasphere.com/docs.',
   '',
   'Set QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1 to silence this notice.',
 ].join('\n')
@@ -49,4 +43,6 @@ export const appendMigrationNotice = (result: CallToolResult): CallToolResult =>
 }
 
 export const startupBanner = (): string =>
-  isSuppressed() ? '' : `qasphere-mcp is archival; QA Sphere serves MCP at ${HOSTED_MCP_URL}`
+  isSuppressed()
+    ? ''
+    : 'qasphere-mcp is archival; QA Sphere serves MCP directly (Settings -> MCP Server)'

--- a/src/migration-notice.ts
+++ b/src/migration-notice.ts
@@ -3,12 +3,20 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 /**
  * This package is archival: QA Sphere now serves MCP itself, so the standalone
  * server exists only for setups that have not migrated yet. Everything below
- * nudges those users towards the hosted endpoint without getting in their way.
+ * nudges those users towards the hosted server without getting in their way.
+ *
+ * Every surface reads QASPHERE_MCP_HIDE_MIGRATION_NOTICE lazily rather than at
+ * module load, so suppression is decided per server process and stays testable.
  */
+const FALSY = new Set(['', '0', 'false', 'no', 'off'])
+
 const isSuppressed = (): boolean => {
   const value = process.env.QASPHERE_MCP_HIDE_MIGRATION_NOTICE
-  return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false'
+  return value !== undefined && !FALSY.has(value.trim().toLowerCase())
 }
+
+const SERVER_SUMMARY =
+  'QA Sphere test management, exposed over MCP by the standalone qasphere-mcp package.'
 
 export const MIGRATION_NOTICE = [
   'Tip: this standalone qasphere-mcp package is no longer maintained.',
@@ -21,18 +29,30 @@ export const MIGRATION_NOTICE = [
   'Set QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1 to silence this notice.',
 ].join('\n')
 
-export const SERVER_INSTRUCTIONS = [
-  'QA Sphere test management, exposed over MCP by the standalone qasphere-mcp package.',
-  '',
-  MIGRATION_NOTICE,
-  '',
-  'Mention this to the user once at a natural point in the conversation, then carry on',
-  'with their task as normal. Do not repeat it or let it interrupt the work.',
-].join('\n')
+/** Built per server construction so the opt-out reaches this surface too. */
+export const buildServerInstructions = (): string =>
+  isSuppressed()
+    ? SERVER_SUMMARY
+    : [
+        SERVER_SUMMARY,
+        '',
+        MIGRATION_NOTICE,
+        '',
+        'Mention this to the user once at a natural point in the conversation, then carry on',
+        'with their task as normal. Do not repeat it or let it interrupt the work.',
+      ].join('\n')
 
 /** Emitted once per server process so a long session is not nagged on every call. */
 let noticeDelivered = false
 
+/**
+ * Rides along on the first tool result of the process. Deliberately the first
+ * *successful* one: tools throw on API errors, so a failed first call leaves the
+ * flag unset and the notice waits rather than being lost to a transient failure.
+ *
+ * The check-then-set below is not a race despite appearances — there is no await
+ * between them, so concurrent tool calls cannot interleave here.
+ */
 export const appendMigrationNotice = (result: CallToolResult): CallToolResult => {
   if (noticeDelivered || isSuppressed()) return result
   noticeDelivered = true

--- a/src/migration-notice.ts
+++ b/src/migration-notice.ts
@@ -1,0 +1,52 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { QASPHERE_TENANT_URL } from './config.js'
+
+/**
+ * This package is archival: QA Sphere now serves MCP itself, so the standalone
+ * server exists only for setups that have not migrated yet. Everything below
+ * nudges those users towards the hosted endpoint without getting in their way.
+ */
+export const HOSTED_MCP_URL = `${QASPHERE_TENANT_URL}/api/mcp`
+
+const HOSTED_MCP_COMMAND = `claude mcp add --transport http qasphere ${HOSTED_MCP_URL} --header "Authorization: Bearer YOUR_API_KEY"`
+
+const isSuppressed = (): boolean => {
+  const value = process.env.QASPHERE_MCP_HIDE_MIGRATION_NOTICE
+  return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false'
+}
+
+export const MIGRATION_NOTICE = [
+  'Tip: this standalone qasphere-mcp package is no longer maintained.',
+  `QA Sphere now serves MCP directly at ${HOSTED_MCP_URL}. The hosted server tracks the`,
+  'API as it changes, exposes every tool your role allows, and needs nothing installed locally.',
+  '',
+  'Set it up in QA Sphere under Settings -> MCP Server, or for Claude Code run:',
+  '',
+  `  ${HOSTED_MCP_COMMAND}`,
+  '',
+  'Set QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1 to silence this notice.',
+].join('\n')
+
+export const SERVER_INSTRUCTIONS = [
+  'QA Sphere test management, exposed over MCP by the standalone qasphere-mcp package.',
+  '',
+  MIGRATION_NOTICE,
+  '',
+  'Mention this to the user once at a natural point in the conversation, then carry on',
+  'with their task as normal. Do not repeat it or let it interrupt the work.',
+].join('\n')
+
+/** Emitted once per server process so a long session is not nagged on every call. */
+let noticeDelivered = false
+
+export const appendMigrationNotice = (result: CallToolResult): CallToolResult => {
+  if (noticeDelivered || isSuppressed()) return result
+  noticeDelivered = true
+  return {
+    ...result,
+    content: [...(result.content ?? []), { type: 'text' as const, text: MIGRATION_NOTICE }],
+  }
+}
+
+export const startupBanner = (): string =>
+  isSuppressed() ? '' : `qasphere-mcp is archival; QA Sphere serves MCP at ${HOSTED_MCP_URL}`

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,11 @@ type ToolCallback = (...args: unknown[]) => Promise<CallToolResult> | CallToolRe
  * Patch `registerTool` once, before the per-domain registrars run, so every tool
  * carries the hosted-MCP notice without each one having to remember to add it.
  * The notice only rides along on the first successful call of the process.
+ *
+ * This assumes the SDK's 3-argument `registerTool(name, config, cb)` shape, which
+ * the casts below hide from the type checker. If an SDK bump changes or overloads
+ * that signature, tools would be wrapped wrongly without a compile error, so keep
+ * tests/e2e/migrationNotice.test.ts green across upgrades.
  */
 const attachMigrationNotice = (server: McpServer) => {
   const register = server.registerTool.bind(server) as (

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,8 +29,19 @@ const attachMigrationNotice = (server: McpServer) => {
     cb: ToolCallback
   ) => unknown
 
-  const withNotice = (name: string, config: unknown, cb: ToolCallback) =>
-    register(name, config, async (...args: unknown[]) => appendMigrationNotice(await cb(...args)))
+  const withNotice = (name: string, config: unknown, cb: ToolCallback) => {
+    // Fail loudly if that assumption ever breaks, rather than registering a tool
+    // whose callback has silently landed in the wrong argument slot.
+    if (typeof cb !== 'function') {
+      throw new TypeError(
+        `registerTool('${name}') was called with an unexpected signature; ` +
+          'the migration-notice wrapper in src/tools/index.ts needs updating for this SDK version.'
+      )
+    }
+    return register(name, config, async (...args: unknown[]) =>
+      appendMigrationNotice(await cb(...args))
+    )
+  }
 
   server.registerTool = withNotice as unknown as McpServer['registerTool']
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { appendMigrationNotice } from '../migration-notice.js'
 import { registerTools as registerCustomFieldsTools } from './customFields.js'
 import { registerTools as registerFoldersTools } from './folders.js'
 import { registerTools as registerProjectsTools } from './projects.js'
@@ -8,7 +10,29 @@ import { registerTools as registerSharedStepsTools } from './shared-steps.js'
 import { registerTools as registerTagsTools } from './tags.js'
 import { registerTools as registerTCasesTools } from './tcases.js'
 
+type ToolCallback = (...args: unknown[]) => Promise<CallToolResult> | CallToolResult
+
+/**
+ * Patch `registerTool` once, before the per-domain registrars run, so every tool
+ * carries the hosted-MCP notice without each one having to remember to add it.
+ * The notice only rides along on the first successful call of the process.
+ */
+const attachMigrationNotice = (server: McpServer) => {
+  const register = server.registerTool.bind(server) as (
+    name: string,
+    config: unknown,
+    cb: ToolCallback
+  ) => unknown
+
+  const withNotice = (name: string, config: unknown, cb: ToolCallback) =>
+    register(name, config, async (...args: unknown[]) => appendMigrationNotice(await cb(...args)))
+
+  server.registerTool = withNotice as unknown as McpServer['registerTool']
+}
+
 export const registerTools = (server: McpServer) => {
+  attachMigrationNotice(server)
+
   registerCustomFieldsTools(server)
   registerFoldersTools(server)
   registerProjectsTools(server)

--- a/tests/e2e/helpers/mcp-client.ts
+++ b/tests/e2e/helpers/mcp-client.ts
@@ -20,10 +20,12 @@ export type McpHandle = {
 let cached: McpHandle | undefined
 let pending: Promise<McpHandle> | undefined
 
-async function startMcpClient(): Promise<McpHandle> {
-  // Truncate the previous run's log so failures show only this run's output.
-  fs.writeFileSync(STDERR_LOG, '')
-
+/**
+ * Single place that knows how to launch the server under test. Both the shared
+ * singleton below and the isolated servers used by per-process tests go through
+ * here, so the two cannot drift apart.
+ */
+async function spawnServer(extraEnv: Record<string, string> = {}) {
   const transport = new StdioClientTransport({
     command: 'npx',
     args: ['tsx', SERVER_ENTRY],
@@ -32,6 +34,7 @@ async function startMcpClient(): Promise<McpHandle> {
       QASPHERE_TENANT_URL: env.QASPHERE_E2E_TENANT_URL,
       QASPHERE_API_KEY: env.QASPHERE_E2E_API_KEY,
       PATH: process.env.PATH ?? '',
+      ...extraEnv,
     },
     stderr: 'pipe',
   })
@@ -40,6 +43,15 @@ async function startMcpClient(): Promise<McpHandle> {
   await client.connect(transport)
 
   const stderr = (transport as unknown as { stderr?: NodeJS.ReadableStream }).stderr
+  return { client, stderr }
+}
+
+async function startMcpClient(): Promise<McpHandle> {
+  // Truncate the previous run's log so failures show only this run's output.
+  fs.writeFileSync(STDERR_LOG, '')
+
+  const { client, stderr } = await spawnServer()
+
   if (stderr && typeof stderr.pipe === 'function') {
     stderr.pipe(fs.createWriteStream(STDERR_LOG, { flags: 'w' }))
   }
@@ -48,6 +60,37 @@ async function startMcpClient(): Promise<McpHandle> {
 
   return {
     client,
+    close: async () => {
+      await client.close()
+    },
+  }
+}
+
+export type IsolatedServer = {
+  client: Client
+  /** Everything the server has written to stderr so far. */
+  stderr: () => string
+  close: () => Promise<void>
+}
+
+/**
+ * A server of one's own, outside the shared singleton. Needed by anything that
+ * asserts on per-process behaviour — startup output, or state that is set up
+ * once per process — where the cached client would give the wrong answer.
+ */
+export async function startIsolatedMcpClient(
+  extraEnv: Record<string, string> = {}
+): Promise<IsolatedServer> {
+  const { client, stderr } = await spawnServer(extraEnv)
+
+  let captured = ''
+  stderr?.on('data', (chunk: Buffer | string) => {
+    captured += String(chunk)
+  })
+
+  return {
+    client,
+    stderr: () => captured,
     close: async () => {
       await client.close()
     },

--- a/tests/e2e/migrationNotice.test.ts
+++ b/tests/e2e/migrationNotice.test.ts
@@ -65,11 +65,24 @@ describe('hosted MCP migration notice', () => {
     expect(textOf(second)).not.toContain(NOTICE_MARKER)
   })
 
-  it('leaves results untouched when QASPHERE_MCP_HIDE_MIGRATION_NOTICE is set', async () => {
+  it('silences every surface when QASPHERE_MCP_HIDE_MIGRATION_NOTICE is set', async () => {
     const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
     try {
+      // The instructions surface is the easiest of the three to leave ungated,
+      // since it is built once rather than per call — assert it explicitly.
+      expect(quiet.getInstructions() ?? '').not.toContain(NOTICE_MARKER)
+
       const result = await quiet.callTool({ name: 'list_projects', arguments: {} })
       expect(textOf(result)).not.toContain(NOTICE_MARKER)
+    } finally {
+      await quiet.close()
+    }
+  })
+
+  it('still describes the server when the notice is suppressed', async () => {
+    const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
+    try {
+      expect(quiet.getInstructions() ?? '').toContain('QA Sphere test management')
     } finally {
       await quiet.close()
     }

--- a/tests/e2e/migrationNotice.test.ts
+++ b/tests/e2e/migrationNotice.test.ts
@@ -1,0 +1,74 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { env } from './helpers/fixtures.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const SERVER_ENTRY = path.join(REPO_ROOT, 'src/index.ts')
+
+type ToolContent = { type: string; text?: string }
+
+const textOf = (result: { content?: unknown }): string =>
+  (Array.isArray(result.content) ? (result.content as ToolContent[]) : [])
+    .map((c) => c.text ?? '')
+    .join('\n')
+
+/**
+ * The notice is emitted once per server process, so these tests need their own
+ * server rather than the singleton shared by the rest of the suite.
+ */
+async function startOwnServer(extraEnv: Record<string, string> = {}): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['tsx', SERVER_ENTRY],
+    cwd: REPO_ROOT,
+    env: {
+      QASPHERE_TENANT_URL: env.QASPHERE_E2E_TENANT_URL,
+      QASPHERE_API_KEY: env.QASPHERE_E2E_API_KEY,
+      PATH: process.env.PATH ?? '',
+      ...extraEnv,
+    },
+  })
+  const client = new Client({ name: 'qasphere-mcp-notice-e2e', version: '0.0.0' })
+  await client.connect(transport)
+  return client
+}
+
+describe('hosted MCP migration notice', () => {
+  let client: Client
+
+  beforeAll(async () => {
+    client = await startOwnServer()
+  })
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  it('advertises the hosted endpoint in the server instructions', () => {
+    const instructions = client.getInstructions() ?? ''
+    expect(instructions).toContain('/api/mcp')
+    expect(instructions).toContain('no longer maintained')
+  })
+
+  it('appends the notice to the first tool result and not to later ones', async () => {
+    const first = await client.callTool({ name: 'list_projects', arguments: {} })
+    expect(textOf(first)).toContain('/api/mcp')
+
+    const second = await client.callTool({ name: 'list_projects', arguments: {} })
+    expect(textOf(second)).not.toContain('/api/mcp')
+  })
+
+  it('leaves results untouched when QASPHERE_MCP_HIDE_MIGRATION_NOTICE is set', async () => {
+    const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
+    try {
+      const result = await quiet.callTool({ name: 'list_projects', arguments: {} })
+      expect(textOf(result)).not.toContain('/api/mcp')
+    } finally {
+      await quiet.close()
+    }
+  })
+})

--- a/tests/e2e/migrationNotice.test.ts
+++ b/tests/e2e/migrationNotice.test.ts
@@ -1,13 +1,5 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { env } from './helpers/fixtures.js'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const REPO_ROOT = path.resolve(__dirname, '../..')
-const SERVER_ENTRY = path.join(REPO_ROOT, 'src/index.ts')
+import { type IsolatedServer, startIsolatedMcpClient } from './helpers/mcp-client.js'
 
 type ToolContent = { type: string; text?: string }
 
@@ -19,72 +11,90 @@ const textOf = (result: { content?: unknown }): string =>
     .map((c) => c.text ?? '')
     .join('\n')
 
-/**
- * The notice is emitted once per server process, so these tests need their own
- * server rather than the singleton shared by the rest of the suite.
- */
-async function startOwnServer(extraEnv: Record<string, string> = {}): Promise<Client> {
-  const transport = new StdioClientTransport({
-    command: 'npx',
-    args: ['tsx', SERVER_ENTRY],
-    cwd: REPO_ROOT,
-    env: {
-      QASPHERE_TENANT_URL: env.QASPHERE_E2E_TENANT_URL,
-      QASPHERE_API_KEY: env.QASPHERE_E2E_API_KEY,
-      PATH: process.env.PATH ?? '',
-      ...extraEnv,
-    },
-  })
-  const client = new Client({ name: 'qasphere-mcp-notice-e2e', version: '0.0.0' })
-  await client.connect(transport)
-  return client
+/** stderr arrives independently of the initialize response, so give it a moment. */
+async function waitForStderr(server: IsolatedServer, timeoutMs = 5000): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (server.stderr().includes('server started')) return server.stderr()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  return server.stderr()
 }
 
+/**
+ * The notice is emitted once per server process, so every case here needs its
+ * own server rather than the singleton shared by the rest of the suite.
+ */
 describe('hosted MCP migration notice', () => {
-  let client: Client
+  describe('by default', () => {
+    let server: IsolatedServer
 
-  beforeAll(async () => {
-    client = await startOwnServer()
+    beforeAll(async () => {
+      server = await startIsolatedMcpClient()
+    })
+
+    afterAll(async () => {
+      await server.close()
+    })
+
+    it('advertises the hosted server in the MCP instructions', () => {
+      const instructions = server.client.getInstructions() ?? ''
+      expect(instructions).toContain(NOTICE_MARKER)
+      expect(instructions).toContain('Settings -> MCP Server')
+    })
+
+    it('logs a startup banner to stderr', async () => {
+      expect(await waitForStderr(server)).toContain('archival')
+    })
+
+    it('appends the notice to the first tool result and not to later ones', async () => {
+      const first = await server.client.callTool({ name: 'list_projects', arguments: {} })
+      expect(textOf(first)).toContain(NOTICE_MARKER)
+
+      const second = await server.client.callTool({ name: 'list_projects', arguments: {} })
+      expect(textOf(second)).not.toContain(NOTICE_MARKER)
+    })
   })
 
-  afterAll(async () => {
-    await client.close()
-  })
+  describe('with QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1', () => {
+    let server: IsolatedServer
 
-  it('advertises the hosted endpoint in the server instructions', () => {
-    const instructions = client.getInstructions() ?? ''
-    expect(instructions).toContain(NOTICE_MARKER)
-    expect(instructions).toContain('Settings -> MCP Server')
-  })
+    beforeAll(async () => {
+      server = await startIsolatedMcpClient({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
+    })
 
-  it('appends the notice to the first tool result and not to later ones', async () => {
-    const first = await client.callTool({ name: 'list_projects', arguments: {} })
-    expect(textOf(first)).toContain(NOTICE_MARKER)
+    afterAll(async () => {
+      await server.close()
+    })
 
-    const second = await client.callTool({ name: 'list_projects', arguments: {} })
-    expect(textOf(second)).not.toContain(NOTICE_MARKER)
-  })
+    it('silences all three surfaces', async () => {
+      // Instructions are the easiest of the three to leave ungated, since they
+      // are built once per process rather than per call — assert them explicitly.
+      expect(server.client.getInstructions() ?? '').not.toContain(NOTICE_MARKER)
+      expect(await waitForStderr(server)).not.toContain('archival')
 
-  it('silences every surface when QASPHERE_MCP_HIDE_MIGRATION_NOTICE is set', async () => {
-    const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
-    try {
-      // The instructions surface is the easiest of the three to leave ungated,
-      // since it is built once rather than per call — assert it explicitly.
-      expect(quiet.getInstructions() ?? '').not.toContain(NOTICE_MARKER)
-
-      const result = await quiet.callTool({ name: 'list_projects', arguments: {} })
+      const result = await server.client.callTool({ name: 'list_projects', arguments: {} })
       expect(textOf(result)).not.toContain(NOTICE_MARKER)
-    } finally {
-      await quiet.close()
-    }
+    })
+
+    it('still describes the server itself', () => {
+      expect(server.client.getInstructions() ?? '').toContain('QA Sphere test management')
+    })
   })
 
-  it('still describes the server when the notice is suppressed', async () => {
-    const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
-    try {
-      expect(quiet.getInstructions() ?? '').toContain('QA Sphere test management')
-    } finally {
-      await quiet.close()
-    }
+  describe('with a falsy QASPHERE_MCP_HIDE_MIGRATION_NOTICE', () => {
+    let server: IsolatedServer
+
+    beforeAll(async () => {
+      server = await startIsolatedMcpClient({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '0' })
+    })
+
+    afterAll(async () => {
+      await server.close()
+    })
+
+    it('treats the notice as enabled', () => {
+      expect(server.client.getInstructions() ?? '').toContain(NOTICE_MARKER)
+    })
   })
 })

--- a/tests/e2e/migrationNotice.test.ts
+++ b/tests/e2e/migrationNotice.test.ts
@@ -11,6 +11,9 @@ const SERVER_ENTRY = path.join(REPO_ROOT, 'src/index.ts')
 
 type ToolContent = { type: string; text?: string }
 
+/** Distinctive enough to spot in a tool result without pinning the exact wording. */
+const NOTICE_MARKER = 'no longer maintained'
+
 const textOf = (result: { content?: unknown }): string =>
   (Array.isArray(result.content) ? (result.content as ToolContent[]) : [])
     .map((c) => c.text ?? '')
@@ -50,23 +53,23 @@ describe('hosted MCP migration notice', () => {
 
   it('advertises the hosted endpoint in the server instructions', () => {
     const instructions = client.getInstructions() ?? ''
-    expect(instructions).toContain('/api/mcp')
-    expect(instructions).toContain('no longer maintained')
+    expect(instructions).toContain(NOTICE_MARKER)
+    expect(instructions).toContain('Settings -> MCP Server')
   })
 
   it('appends the notice to the first tool result and not to later ones', async () => {
     const first = await client.callTool({ name: 'list_projects', arguments: {} })
-    expect(textOf(first)).toContain('/api/mcp')
+    expect(textOf(first)).toContain(NOTICE_MARKER)
 
     const second = await client.callTool({ name: 'list_projects', arguments: {} })
-    expect(textOf(second)).not.toContain('/api/mcp')
+    expect(textOf(second)).not.toContain(NOTICE_MARKER)
   })
 
   it('leaves results untouched when QASPHERE_MCP_HIDE_MIGRATION_NOTICE is set', async () => {
     const quiet = await startOwnServer({ QASPHERE_MCP_HIDE_MIGRATION_NOTICE: '1' })
     try {
       const result = await quiet.callTool({ name: 'list_projects', arguments: {} })
-      expect(textOf(result)).not.toContain('/api/mcp')
+      expect(textOf(result)).not.toContain(NOTICE_MARKER)
     } finally {
       await quiet.close()
     }


### PR DESCRIPTION
QA Sphere now serves MCP itself, so this standalone package only exists for setups that haven't migrated. The README says so, but nobody re-reads the README of a server that's already working — so the running server now says it too.

## Three surfaces

1. **MCP `instructions`** — clients hand this to the model at the start of every session. It carries the tip and asks the model to relay it once, then get on with the user's task.
2. **First tool result** — the notice is appended to the first successful tool call of the process, which is what actually lands in the conversation. `registerTool` is patched once in `tools/index.ts`, so no individual tool has to remember it and nothing is appended on subsequent calls.
3. **stderr banner** at startup, for anyone reading MCP logs.

```
Tip: this standalone qasphere-mcp package is no longer maintained.
QA Sphere now serves MCP directly. The hosted server tracks the API as it changes,
exposes every tool your role allows, and needs nothing installed locally.

To switch, see Settings -> MCP Server in QA Sphere, or the QA Sphere documentation
at https://qasphere.com/docs.

Set QASPHERE_MCP_HIDE_MIGRATION_NOTICE=1 to silence this notice.
```

The copy deliberately points at **Settings -> MCP Server** rather than spelling out a client-specific setup command: this notice reaches users of every MCP client, and the product page already generates the right command per assistant. That also keeps this repo from carrying a second copy of setup instructions that can drift. The README callout is updated to match.

`QASPHERE_MCP_HIDE_MIGRATION_NOTICE` silences all three surfaces, for anyone who can't migrate yet.

## Verification

Against a live tenant: **56 passed, 2 skipped** (was 53 + 2 — the wrapper doesn't disturb the existing suite). New `tests/e2e/migrationNotice.test.ts` spawns its own server process, since the notice is once-per-process and the rest of the suite shares a singleton, and covers instructions, first-call-only behaviour, and the opt-out.

Tool results are unaffected structurally: the notice is an extra `content` block, and `structuredContent` — which is what schema-aware clients and the e2e helper read — is untouched.

