### PR TITLE
Report the package's own version over MCP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
@@ -7,11 +8,19 @@ import { LoggingTransport } from './LoggingTransport.js'
 import { buildServerInstructions, startupBanner } from './migration-notice.js'
 import { registerTools } from './tools/index.js'
 
+// Read from our own package.json rather than npm_package_version: that variable
+// describes whichever package.json npm happened to load, which under `npx
+// qasphere-mcp` is the consuming project's, and is unset when the binary is run
+// directly. Resolved relative to this module, so it works from src/ and dist/.
+const { version } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+) as { version: string }
+
 // Create MCP server
 const server = new McpServer(
   {
     name: 'qasphere-mcp',
-    version: process.env.npm_package_version || '0.0.0',
+    version,
     description: 'QA Sphere MCP server for fetching test cases and projects.',
   },
   { instructions: buildServerInstructions() }

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -1,6 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { beforeAll, describe, expect, it } from 'vitest'
-import { getMcpHandle } from './helpers/mcp-client.js'
+import { getMcpHandle, startIsolatedMcpClient } from './helpers/mcp-client.js'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const PKG_VERSION = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'))
+  .version as string
 
 const EXPECTED_TOOLS = [
   'get_project',
@@ -40,6 +47,21 @@ describe('smoke', () => {
     for (const tool of result.tools) {
       expect(tool.inputSchema, `${tool.name} missing inputSchema`).toBeDefined()
       expect(tool.outputSchema, `${tool.name} missing outputSchema`).toBeDefined()
+    }
+  })
+
+  /**
+   * The version used to come from npm_package_version, which describes whichever
+   * package.json npm loaded — the consuming project's under `npx qasphere-mcp`,
+   * and nothing at all when the binary is run directly. A hostile value here must
+   * not reach the handshake.
+   */
+  it('reports its own package version, not npm_package_version', async () => {
+    const server = await startIsolatedMcpClient({ npm_package_version: '9.9.9-bogus' })
+    try {
+      expect(server.client.getServerVersion()?.version).toBe(PKG_VERSION)
+    } finally {
+      await server.close()
     }
   })
 })


### PR DESCRIPTION
## Problem

`src/index.ts` passed `process.env.npm_package_version` to `McpServer`. That variable describes whichever `package.json` npm happened to load, not this package:

- launched as `npx qasphere-mcp` from a project directory, it is **the consuming project's** version;
- launched directly (an MCP client configured with an absolute path to the bin), it is **unset**, so the server fell back to `'0.0.0'`.

Either way the version a client sees in the initialize handshake — and shows in its logs and UI — was wrong. Pre-existing since at least v0.4.1.

## Fix

Read `version` from our own `package.json`, resolved relative to the module (`new URL('../package.json', import.meta.url)`) so it works identically from `src/` under tsx and from `dist/` when installed.

## Verification

Packed a 0.5.0 tarball and installed it into a throwaway consumer project whose own version is `9.9.9`:

| launch | before | after |
| --- | --- | --- |
| `npx qasphere-mcp` | `9.9.9` | `0.5.0` |
| direct `node .../bin/qasphere-mcp` | `0.0.0` | `0.5.0` |

Added a regression test to `tests/e2e/smoke.test.ts` that starts an isolated server with `npm_package_version=9.9.9-bogus` and asserts the handshake still reports the real version.

Full e2e suite run against a live tenant: **60 passed, 2 skipped** (the two skips are pre-existing — no shared steps/preconditions seeded in the target project).

## Why now

This is the last change queued before cutting **v0.5.0**, which will be the final release of this archival package — worth having it report itself honestly.

https://claude.ai/code/session_01167rkMZNcyAXn565FALdoP